### PR TITLE
Db interest table

### DIFF
--- a/app/models/interest.rb
+++ b/app/models/interest.rb
@@ -1,0 +1,4 @@
+class Interest < ApplicationRecord
+    has_many :user_interests
+    has_many :users, through: :user_interests 
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,6 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+  has_many :user_interests
+  has_many :interests, through: :user_interests 
 end

--- a/app/models/user_interest.rb
+++ b/app/models/user_interest.rb
@@ -1,0 +1,4 @@
+class UserInterest < ApplicationRecord
+  belongs_to :user
+  belongs_to :interest
+end

--- a/app/models/user_interest.rb
+++ b/app/models/user_interest.rb
@@ -1,4 +1,6 @@
 class UserInterest < ApplicationRecord
+  validates_uniqueness_of :user_id, conditions: -> { where(isPrimaryRole: true) }
+
   belongs_to :user
   belongs_to :interest
 end

--- a/db/migrate/20231009100841_create_interests.rb
+++ b/db/migrate/20231009100841_create_interests.rb
@@ -1,0 +1,10 @@
+class CreateInterests < ActiveRecord::Migration[7.1]
+  def change
+    create_table :interests do |t|
+      t.string :name
+      t.boolean :isRole
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20231009101043_create_user_interests.rb
+++ b/db/migrate/20231009101043_create_user_interests.rb
@@ -1,0 +1,10 @@
+class CreateUserInterests < ActiveRecord::Migration[7.1]
+  def change
+    create_table :user_interests do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :interest, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20231009104342_add_uniqueness_constraint_to_user_interests.rb
+++ b/db/migrate/20231009104342_add_uniqueness_constraint_to_user_interests.rb
@@ -1,0 +1,5 @@
+class AddUniquenessConstraintToUserInterests < ActiveRecord::Migration[7.1]
+  def change
+    add_index :user_interests, [:user_id, :interest_id], unique: true, name: 'unique_interest_per_user'
+  end
+end

--- a/db/migrate/20231009114344_add_is_primary_role_to_user_interest.rb
+++ b/db/migrate/20231009114344_add_is_primary_role_to_user_interest.rb
@@ -1,0 +1,6 @@
+class AddIsPrimaryRoleToUserInterest < ActiveRecord::Migration[7.1]
+  def change
+    add_column :user_interests, :isPrimaryRole, :boolean, default: false
+
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_10_09_101043) do
+ActiveRecord::Schema[7.1].define(version: 2023_10_09_104342) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -27,6 +27,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_10_09_101043) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["interest_id"], name: "index_user_interests_on_interest_id"
+    t.index ["user_id", "interest_id"], name: "unique_interest_per_user", unique: true
     t.index ["user_id"], name: "index_user_interests_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,25 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_10_06_201048) do
+ActiveRecord::Schema[7.1].define(version: 2023_10_09_101043) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "interests", force: :cascade do |t|
+    t.string "name"
+    t.boolean "isRole"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "user_interests", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "interest_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["interest_id"], name: "index_user_interests_on_interest_id"
+    t.index ["user_id"], name: "index_user_interests_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -26,4 +42,6 @@ ActiveRecord::Schema[7.1].define(version: 2023_10_06_201048) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "user_interests", "interests"
+  add_foreign_key "user_interests", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_10_09_104342) do
+ActiveRecord::Schema[7.1].define(version: 2023_10_09_114344) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -26,6 +26,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_10_09_104342) do
     t.bigint "interest_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "isPrimaryRole", default: false
     t.index ["interest_id"], name: "index_user_interests_on_interest_id"
     t.index ["user_id", "interest_id"], name: "unique_interest_per_user", unique: true
     t.index ["user_id"], name: "index_user_interests_on_user_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -34,9 +34,9 @@ interestLast = Interest.last
 user1.user_interests.create(
 interest: interest
 )
-user1.user_interests.create(
-interest: interest
-)
+# user1.user_interests.create(
+# interest: interest
+# )
 user1.user_interests.create(
 interest: interestLast
 )

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -32,14 +32,16 @@ interest = Interest.first
 interestLast = Interest.last
 
 user1.user_interests.create(
-interest: interest
+interest: interest,
+isPrimaryRole: true
 )
 # user1.user_interests.create(
 # interest: interest
 # )
 user1.user_interests.create(
-interest: interestLast
-)
+interest: interestLast,
+isPrimaryRole: true
+)   #this one is not created because isPrimaryRole can not be true for multiple entries
 
 user2.user_interests.create(
 interest: interest

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,3 +7,40 @@
 #   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
+UserInterest.destroy_all
+
+User.destroy_all
+
+user1 = User.create! :email => 'john@gmail.com', :password => 'topsecret', :password_confirmation => 'topsecret'
+user2 = User.create! :email => 'sally@gmail.com', :password => 'topsecret', :password_confirmation => 'topsecret'
+user3 = User.create! :email => 'jane@gmail.com', :password => 'topsecret', :password_confirmation => 'topsecret'
+
+Interest.destroy_all
+
+Interest.create([{
+    name: "Software Engineer",
+    isRole: true
+},
+{
+    name: "Data Engineer",
+    isRole: true
+},{
+    name: "Leadership",
+    isRole: false
+}])
+interest = Interest.first
+interestLast = Interest.last
+
+user1.user_interests.create(
+interest: interest
+)
+user1.user_interests.create(
+interest: interest
+)
+user1.user_interests.create(
+interest: interestLast
+)
+
+user2.user_interests.create(
+interest: interest
+)

--- a/test/fixtures/interests.yml
+++ b/test/fixtures/interests.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  isRole: false
+
+two:
+  name: MyString
+  isRole: false

--- a/test/fixtures/user_interests.yml
+++ b/test/fixtures/user_interests.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  interest: one
+
+two:
+  user: two
+  interest: two

--- a/test/models/interest_test.rb
+++ b/test/models/interest_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class InterestTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/user_interest_test.rb
+++ b/test/models/user_interest_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UserInterestTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Added the interest table and joining user_interest table. 
Moved the 'primary role' join to a boolean in the user_interest table (is role) - can add constraints to ensure user only exists with one 'isRole' in table? But this design reduces complexity.

